### PR TITLE
Fix NPE in case a dimension has no LostCityChunkGenerator

### DIFF
--- a/src/main/java/mcjty/lostcities/dimensions/world/LostWorldFilteredBiomeProvider.java
+++ b/src/main/java/mcjty/lostcities/dimensions/world/LostWorldFilteredBiomeProvider.java
@@ -54,6 +54,10 @@ public class LostWorldFilteredBiomeProvider extends BiomeProvider {
             return originalBiome;
         }
 
+        if(getProvider() == null) {
+            return originalBiome;
+        }
+
         if (profile.isSpace() && profile.CITYSPHERE_LANDSCAPE_OUTSIDE) {
             int chunkX = (pos.getX()) >> 4;
             int chunkZ = (pos.getZ()) >> 4;
@@ -80,6 +84,11 @@ public class LostWorldFilteredBiomeProvider extends BiomeProvider {
         if (!(world instanceof WorldServer)) {
             return;
         }
+
+        if(getProvider() == null) {
+            return;
+        }
+
         LostCityProfile profile = WorldTypeTools.getProfile(world);
         if (profile.isSpace() && profile.CITYSPHERE_LANDSCAPE_OUTSIDE) {
             int chunkX = (topx) >> 4;


### PR DESCRIPTION
Seen happening on a Direwolf20 1.12.2 Server with world type lostcities_bop. Placing a Compact Machine inside a city sphere and entering it, i.e. teleporting to the CM dimension causes the server to enter a crash loop.

This might not be the proper way to fix this issue?
Maybe I really need to change something in Compact Machines itself?

Crash log:
```
java.lang.NullPointerException: Getting biome
	at mcjty.lostcities.dimensions.world.lost.CitySphere.getCitySphere(CitySphere.java:422)
	at mcjty.lostcities.dimensions.world.LostWorldFilteredBiomeProvider.translateList(LostWorldFilteredBiomeProvider.java:92)
	at mcjty.lostcities.dimensions.world.LostWorldFilteredBiomeProvider.func_76933_b(LostWorldFilteredBiomeProvider.java:133)
	at mcjty.lostcities.dimensions.world.LostWorldFilteredBiomeProvider.func_76931_a(LostWorldFilteredBiomeProvider.java:147)
	at net.minecraft.world.biome.BiomeCache$Block.<init>(SourceFile:27)
	at net.minecraft.world.biome.BiomeCache.func_76840_a(SourceFile:48)
	at net.minecraft.world.biome.BiomeCache.func_180284_a(SourceFile:57)
	at net.minecraft.world.biome.BiomeProvider.func_180300_a(BiomeProvider.java:65)
	at net.minecraft.world.chunk.Chunk.func_177411_a(Chunk.java:1213)
	at net.minecraft.world.World.getBiomeForCoordsBody(World.java:159)
	at net.minecraft.world.WorldProvider.getBiomeForCoords(WorldProvider.java:410)
	at net.minecraft.world.World.func_180494_b(World.java:148)
	at net.minecraft.world.World.canBlockFreezeBody(World.java:2695)
	at net.minecraft.world.WorldProvider.canBlockFreeze(WorldProvider.java:489)
	at net.minecraft.world.World.func_175670_e(World.java:2690)
	at net.minecraft.world.World.func_175662_w(World.java:2685)
	at net.minecraft.world.WorldServer.func_147456_g(WorldServer.java:438)
	at net.minecraft.world.WorldServer.func_72835_b(WorldServer.java:225)
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:754)
	at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:396)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:666)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:524)
	at java.lang.Thread.run(Unknown Source)
```