### PR TITLE
fix for #271 (worldgen crash)

### DIFF
--- a/src/main/java/mcjty/lostcities/worldgen/ChunkDriver.java
+++ b/src/main/java/mcjty/lostcities/worldgen/ChunkDriver.java
@@ -129,13 +129,7 @@ public class ChunkDriver {
         if (adjacent.getBlock() instanceof LadderBlock) {
             return adjacent;
         }
-        BlockState newAdjacent = null;
-        try {
-            newAdjacent = adjacent.getBlock().updatePostPlacement(adjacent, direction, state, region, pos, current);
-        } catch (Exception e) {
-            // We got an exception. For example for beehives there can potentially be a problem so in this case we just ignore it
-            return adjacent;
-        }
+        BlockState newAdjacent = adjacent.updatePostPlacement(direction, state, region, pos, pos.offset(direction));
         if (newAdjacent != adjacent) {
             IChunk chunk = region.getChunk(pos);
             if (chunk == thisChunk || chunk.getStatus().isAtLeast(ChunkStatus.FULL)) {


### PR DESCRIPTION
The Block.updatePostPlacement method takes an absolute position
as its last coordinate, but was being given a coordinate relative
to the current ChunkDriver chunk during world gen, causing a crash
when called on a block type that attempts to look up the block
at the given position in a WorldGenRegion that does not contain
the origin.