### PR TITLE
City beautification

### DIFF
--- a/src/main/java/mcjty/lostcities/worldgen/ChunkDriver.java
+++ b/src/main/java/mcjty/lostcities/worldgen/ChunkDriver.java
@@ -61,7 +61,7 @@ public class ChunkDriver {
     }
 
     private void setBlock(BlockPos p, BlockState state) {
-        cache.put(p, state);
+        if(state != null) cache.put(p, state);
     }
 
     // This version of getBlock() is less optimal but it will work for different chunks
@@ -288,6 +288,9 @@ public class ChunkDriver {
             state = state.setValue(WallBlock.SOUTH_WALL, canAttachWall(southState));
         } else if (state.getBlock() instanceof StairBlock) {
             state = state.setValue(StairBlock.SHAPE, getShapeProperty(state, pos.set(cx, cy, cz)));
+        } else if (state.getBlock() instanceof StructureVoidBlock){
+            //like an alpha channel - but for parts! Uses whatever block was previously there instead of changing it!
+            return null;
         }
         return state;
     }

--- a/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
+++ b/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
@@ -91,6 +91,10 @@ public class LostCityTerrainFeature {
 
     private static BlockState[] randomLeafs = null;
 
+    private static BlockState[] randomDirt = null;
+
+    static Material[] plantMaterials = new Material[]{Material.PLANT, Material.WATER_PLANT, Material.REPLACEABLE_WATER_PLANT, Material.REPLACEABLE_PLANT, Material.REPLACEABLE_FIREPROOF_PLANT, Material.BAMBOO_SAPLING, Material.BAMBOO, Material.WOOD, Material.LEAVES};
+
     private final ChunkDriver driver;
 
     private final IDimensionInfo provider;
@@ -137,6 +141,31 @@ public class LostCityTerrainFeature {
             }
         }
         return randomLeafs[fastrand128()];
+    }
+
+    //Gets rubble block - regenerates list if empty
+    public static BlockState getRandomDirt() {
+        if (randomDirt == null) {
+            BlockState mBricks = Blocks.MOSSY_STONE_BRICKS.defaultBlockState();
+            BlockState mCobble = Blocks.MOSSY_COBBLESTONE.defaultBlockState();
+            BlockState moss = Blocks.MOSS_BLOCK.defaultBlockState();
+
+            randomDirt = new BlockState[128];
+            int i = 0;
+            while (i < 20) {
+                randomDirt[i] = mBricks;
+                i++;
+            }
+            while (i < 60) {
+                randomDirt[i] = mCobble;
+                i++;
+            }
+            while (i < randomDirt.length) {
+                randomDirt[i] = moss;
+                i++;
+            }
+        }
+        return randomDirt[fastrand128()];
     }
 
     public static Set<BlockState> getRailStates() {
@@ -1107,13 +1136,21 @@ public class LostCityTerrainFeature {
         }
         return false;
     }
+    // Return true if state is Empty or Plant based - stops (most) funny tree/mushroom action on chunk borders
+    private static boolean isFoliageOrEmpty(BlockState state) {
+        Material material = state.getMaterial();
+        if(isEmpty(state)){
+            return true;
+        }
+        return Arrays.stream(plantMaterials).anyMatch((material1 -> material1 == material));
+    }
 
     private void moveUp(int x, int z, int height, boolean dowater) {
         // Find the first non-empty block starting at the given height
         driver.current(x, height, z);
         int minHeight = provider.getWorld().getMinBuildHeight();
         // We assume here we are not in a void chunk
-        while (isEmpty(driver.getBlock()) && driver.getY() > minHeight) {
+        while (isFoliageOrEmpty(driver.getBlock()) && driver.getY() > minHeight) {
             driver.decY();
         }
 
@@ -1140,7 +1177,7 @@ public class LostCityTerrainFeature {
         int y = 255;
         driver.current(x, y, z);
         // We assume here we are not in a void chunk
-        while (driver.getBlock() == air && driver.getY() > height) {
+        while (isFoliageOrEmpty(driver.getBlock()) && driver.getY() > height) {
             driver.decY();
         }
 
@@ -1289,6 +1326,19 @@ public class LostCityTerrainFeature {
                     for (int z = 0; z < 16; ++z) {
                         driver.setBlockRange(x, info.groundLevel, z, info.waterLevel, liquid);
                     }
+                }
+            }
+        }
+
+        //city surface leveling - for prettier cities
+        //note: Better results may be achieved with terrain noise adjustment (like how newer structures do it)
+        int ground = info.getCityGroundLevel();
+        for (int x = 0; x < 16; x++) {
+            for (int z = 0; z < 16; z++) {
+                boolean moved = moveDown(x, z, ground + 1, info.waterLevel > info.groundLevel);
+
+                if (!moved) {
+                    moveUp(x, z, ground, info.waterLevel > info.groundLevel);
                 }
             }
         }
@@ -1647,13 +1697,18 @@ public class LostCityTerrainFeature {
                     if (c != air && c != liquid) {
                         for (int i = 0; i < vr; i++) {
                             if (isEmpty(driver.getBlock())) {
-                                driver.add(base);
+                                driver.add(getRandomDirt());
                             } else {
                                 driver.incY();
                             }
                         }
                     }
-                    if (driver.getBlockDown() == base) {
+                    //first round may not have generated this - stops crash on create world
+                    if(randomDirt == null) {
+                        getRandomDirt();
+                    }
+                    BlockState leafBaseState = driver.getBlockDown();
+                    if (leafBaseState == base || Arrays.stream(randomDirt).anyMatch((b) -> b == leafBaseState)) {
                         for (int i = 0; i < vl; i++) {
                             if (isEmpty(driver.getBlock())) {
                                 driver.add(getRandomLeaf());
@@ -1792,9 +1847,9 @@ public class LostCityTerrainFeature {
         if (canDoParks) {
             int height = info.getCityGroundLevel();
             // In default landscape type we clear the landscape on top of the building
-            if (profile.isDefault()) {
-                clearToMax(info, heightmap, height);
-            }
+            //if (profile.isDefault()) {
+                //clearToMax(info, heightmap, height);
+            //}
 
             BuildingInfo.StreetType streetType = info.streetType;
             boolean elevated = info.isElevatedParkSection();

--- a/src/main/resources/data/lostcities/lostcities/palettes/default.json
+++ b/src/main/resources/data/lostcities/lostcities/palettes/default.json
@@ -22,7 +22,7 @@
     },
     {
       "char": "b",
-      "block": "minecraft:stone"
+      "block": "minecraft:structure_void"
     },
     {
       "char": "B",

--- a/src/main/resources/data/lostcities/lostcities/palettes/default_desert.json
+++ b/src/main/resources/data/lostcities/lostcities/palettes/default_desert.json
@@ -22,7 +22,7 @@
     },
     {
       "char": "b",
-      "block": "minecraft:stone"
+      "block": "minecraft:structure_void"
     },
     {
       "char": "B",


### PR DESCRIPTION
returned grass (and all other biome blocks) to the cities

fixed near ocean underground chunk errors as a byproduct

made rubble generate moss/mossy cobble/mossy bricks instead of stone
![2022-09-14_01 31 55](https://user-images.githubusercontent.com/33583954/190099428-41afb219-888a-421c-9f91-93533bc5e672.png)

It is not perfect, but I think it is much better than stone cities
