### PR TITLE
Changed hardAir to structure void. - 1.18.2

### DIFF
--- a/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
+++ b/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
@@ -101,7 +101,7 @@ public class LostCityTerrainFeature {
         this.ruinNoise = new NoiseGeneratorPerlin(rand, 4);
 
         air = Blocks.AIR.defaultBlockState();
-        hardAir = Blocks.COMMAND_BLOCK.defaultBlockState();
+        hardAir = Blocks.STRUCTURE_VOID.defaultBlockState();
 
 //        islandTerrainGenerator.setup(provider.getWorld().getWorld(), provider);
 //        cavernTerrainGenerator.setup(provider.getWorld().getWorld(), provider);

--- a/src/main/resources/data/lostcities/lostcities/palettes/common.json
+++ b/src/main/resources/data/lostcities/lostcities/palettes/common.json
@@ -221,7 +221,7 @@
     },
     {
       "char": "~",
-      "block": "minecraft:command_block"
+      "block": "minecraft:structure_void"
     }
   ]
 }


### PR DESCRIPTION
Previously, command block was used to set hardAir for building generation, this results in Command Block unable to be actually being used in any of the part, right now it's been changed into structure void which removes the unusability of command block.