### PR TITLE
1.20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+build/*
+.gradle/*
+.idea/*

--- a/src/main/java/mcjty/lostcities/api/LostCityEvent.java
+++ b/src/main/java/mcjty/lostcities/api/LostCityEvent.java
@@ -1,5 +1,6 @@
 package mcjty.lostcities.api;
 
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraftforge.common.MinecraftForge;
@@ -187,7 +188,8 @@ public class LostCityEvent extends Event {
 
     /**
      * PostGenHighwayChunkEvent is fired right after generation of a chunk containing a highway.<br>
-     * NOTE! This will be called for both city and outside chunks but only if a highway has been generated. <br>
+     * NOTE! This will be called for both city and outside chunks but only if a highway has been
+     * generated but before supports have been. <br>
      * <br>
      * {@link #primer} contains the {@link ChunkAccess} for this chunk. <br>
      * <br>
@@ -199,14 +201,32 @@ public class LostCityEvent extends Event {
      **/
     public static class PostGenHighwayChunkEvent extends LostCityEvent {
         private final ChunkAccess primer;
+        private ResourceLocation oldPart;
+        private ResourceLocation newPart = new ResourceLocation("");
+        private boolean changed = false;
 
-        public PostGenHighwayChunkEvent(WorldGenLevel world, ILostCities lostCities, int chunkX, int chunkZ, ChunkAccess primer) {
+        public PostGenHighwayChunkEvent(WorldGenLevel world, ILostCities lostCities, int chunkX, int chunkZ, ChunkAccess primer, ResourceLocation part) {
             super(world, lostCities, chunkX, chunkZ);
             this.primer = primer;
+            this.oldPart = part;
         }
 
         public ChunkAccess getChunkAccess() {
             return primer;
+        }
+
+        public ResourceLocation getPart() {
+            return oldPart;
+        }
+        public ResourceLocation getNewPart() {
+            return newPart;
+        }
+        public void setPart(ResourceLocation part) {
+            newPart = part;
+            changed = true;
+        }
+        public boolean isChanged() {
+            return changed;
         }
     }
 

--- a/src/main/java/mcjty/lostcities/api/LostCityEvent.java
+++ b/src/main/java/mcjty/lostcities/api/LostCityEvent.java
@@ -82,7 +82,7 @@ public class LostCityEvent extends Event {
      * but keep in mind that the street or building will be generated after this and might overwrite what you did.<br>
      * NOTE! This will only be called for city chunks (buildings or street). <br>
      * <br>
-     * {@link #primer} contains the {@link ChunkPrimer} for this chunk. This primer will already be filled with stone up to city level. <br>
+     * {@link #primer} contains the {@link ChunkAccess} for this chunk. This primer will already be filled with stone up to city level. <br>
      * <br>
      * This event is {@link Cancelable}.<br>
      * <br>
@@ -110,7 +110,7 @@ public class LostCityEvent extends Event {
      * This is mostly useful in case you want to modify the standard Lost City building/street after it has been generated.<br>
      * NOTE! This will only be called for city chunks (buildings or street). <br>
      * <br>
-     * {@link #primer} contains the {@link ChunkPrimer} for this chunk. This primer will already have the building and street stuff in it. <br>
+     * {@link #primer} contains the {@link ChunkAccess} for this chunk. This primer will already have the building and street stuff in it. <br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>
@@ -136,7 +136,7 @@ public class LostCityEvent extends Event {
      * This is fired right after generation of the chunk but before highways, subways and other stuff like that.
      * NOTE! This will NOT be called for city chunks (buildings or street). <br>
      * <br>
-     * {@link #primer} contains the {@link ChunkPrimer} for this chunk. <br>
+     * {@link #primer} contains the {@link ChunkAccess} for this chunk. <br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>
@@ -163,7 +163,7 @@ public class LostCityEvent extends Event {
      * to modify the chunk before explosion damage is calculated.
      * NOTE! This will be called for every chunk (city or normal). <br>
      * <br>
-     * {@link #primer} contains the {@link ChunkPrimer} for this chunk. <br>
+     * {@link #primer} contains the {@link ChunkAccess} for this chunk. <br>
      * <br>
      * This event is {@link Cancelable}.<br>
      * <br>
@@ -176,6 +176,31 @@ public class LostCityEvent extends Event {
         private final ChunkAccess primer;
 
         public PreExplosionEvent(WorldGenLevel world, ILostCities lostCities, int chunkX, int chunkZ, ChunkAccess primer) {
+            super(world, lostCities, chunkX, chunkZ);
+            this.primer = primer;
+        }
+
+        public ChunkAccess getChunkAccess() {
+            return primer;
+        }
+    }
+
+    /**
+     * PostGenHighwayChunkEvent is fired right after generation of a chunk containing a highway.<br>
+     * NOTE! This will be called for both city and outside chunks but only if a highway has been generated. <br>
+     * <br>
+     * {@link #primer} contains the {@link ChunkAccess} for this chunk. <br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+     **/
+    public static class PostGenHighwayChunkEvent extends LostCityEvent {
+        private final ChunkAccess primer;
+
+        public PostGenHighwayChunkEvent(WorldGenLevel world, ILostCities lostCities, int chunkX, int chunkZ, ChunkAccess primer) {
             super(world, lostCities, chunkX, chunkZ);
             this.primer = primer;
         }

--- a/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
+++ b/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
@@ -903,6 +903,10 @@ public class LostCityTerrainFeature {
                 generateHighwayPart(info, levelZ, Transform.ROTATE_90, info.getXmax(), info.getXmax(), false);
             }
         }
+        if (levelX >=0 || levelZ >=0) {
+            LostCityEvent.PostGenHighwayChunkEvent postevent = new LostCityEvent.PostGenHighwayChunkEvent(provider.getWorld(), LostCities.lostCitiesImp, chunkX, chunkZ, driver.getPrimer());
+            MinecraftForge.EVENT_BUS.post(postevent);
+        }
     }
 
     private static boolean isClearableAboveHighway(BlockState st) {

--- a/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
+++ b/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
@@ -903,10 +903,6 @@ public class LostCityTerrainFeature {
                 generateHighwayPart(info, levelZ, Transform.ROTATE_90, info.getXmax(), info.getXmax(), false);
             }
         }
-        if (levelX >=0 || levelZ >=0) {
-            LostCityEvent.PostGenHighwayChunkEvent postevent = new LostCityEvent.PostGenHighwayChunkEvent(provider.getWorld(), LostCities.lostCitiesImp, chunkX, chunkZ, driver.getPrimer());
-            MinecraftForge.EVENT_BUS.post(postevent);
-        }
     }
 
     private static boolean isClearableAboveHighway(BlockState st) {
@@ -949,6 +945,14 @@ public class LostCityTerrainFeature {
                     }
                 }
             }
+        }
+
+        LostCityEvent.PostGenHighwayChunkEvent postevent = new LostCityEvent.PostGenHighwayChunkEvent(provider.getWorld(), LostCities.lostCitiesImp, info.chunkX, info.chunkZ, driver.getPrimer(), part.getId());
+        MinecraftForge.EVENT_BUS.post(postevent);
+
+        if (postevent.isChanged()) {
+            part = AssetRegistries.PARTS.getOrThrow(provider.getWorld(), postevent.getNewPart().toString());
+            generatePart(info, part, transform, 0, highwayGroundLevel, 0, true);
         }
 
         Character support = part.getMetaChar(ILostCities.META_SUPPORT);


### PR DESCRIPTION
added an event that runs right after a highway has been generated but before support pillarsenableing a replacement building part to be chosen and generated in place of a standard highway.