### PR TITLE
- Fixed an issue where building has an extreme chance to not generate.

### DIFF
--- a/src/main/java/mcjty/lostcities/varia/Tools.java
+++ b/src/main/java/mcjty/lostcities/varia/Tools.java
@@ -104,7 +104,7 @@ public class Tools {
                 return pair;
             }
         }
-        return null;
+        return elements.get(elements.size() - 1);
     }
 
     public static Iterable<Holder<Block>> getBlocksForTag(TagKey<Block> rl) {


### PR DESCRIPTION
- Fixed an issue where building has an extreme chance to not generate due to the float decimal number has garbage value in it.
This can be seen in getting the random building selector chance. As there is an extreme chance that the floating number receive loss of precision and in exchange it increased the decimal values, resulting the number didn't go below 0.0.

In this case, my proposal of the fix is just return the last element of the list since we already did the element checking on the very beginning of this function.
![image](https://github.com/McJtyMods/LostCities/assets/31058251/96e86093-cc7c-423e-a04e-79443a56b9cf)
[message (2).txt](https://github.com/McJtyMods/LostCities/files/13275441/message.2.txt)
