### PR TITLE
Fixed poi related objects always show up as air.

### DIFF
--- a/src/main/java/mcjty/lostcities/worldgen/GlobalTodo.java
+++ b/src/main/java/mcjty/lostcities/worldgen/GlobalTodo.java
@@ -1,5 +1,6 @@
 package mcjty.lostcities.worldgen;
 
+import mcjty.lostcities.LostCities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -92,10 +93,10 @@ public class GlobalTodo extends SavedData {
         });
         tag.put("blockentities", blockEntities);
         ListTag poi = new ListTag();
-        todoPoi.entrySet().forEach(entry -> {
+        todoPoi.forEach((pos, state) -> {
             CompoundTag pTag = new CompoundTag();
-            pTag.put("pos", NbtUtils.writeBlockPos(entry.getKey()));
-            pTag.put("state", NbtUtils.writeBlockState(entry.getValue()));
+            pTag.put("pos", NbtUtils.writeBlockPos(pos));
+            pTag.put("state", NbtUtils.writeBlockState(state));
             poi.add(pTag);
         });
         return tag;
@@ -147,9 +148,7 @@ public class GlobalTodo extends SavedData {
 
         var copyPoi = this.todoPoi;
         this.todoPoi = new HashMap<>();
-        copyPoi.entrySet().forEach(entry -> {
-            BlockPos pos = entry.getKey();
-            BlockState state = entry.getValue();
+        copyPoi.forEach((pos, state) -> {
             if (!level.getPoiManager().getType(pos).isPresent()) {
                 if (level.getBlockState(pos).getBlock() == state.getBlock()) {
                     level.setBlock(pos, state, Block.UPDATE_ALL);

--- a/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
+++ b/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
@@ -539,8 +539,11 @@ public class LostCityTerrainFeature {
 
     private void doNormalChunk(BuildingInfo info, ChunkHeightmap heightmap) {
 //        debugClearChunk(chunkX, chunkZ, primer);
+        // TqLxQuanZ: Used for detect the shape correcting in the normal chunk, if there's a terrain shape correct happening,
+        // do not attempt to generate scattered building as they'll float in midair since it uses heightmap.
+        boolean trimmed = false;
         if (profile.isDefault() || profile.isSpheres()) {
-            correctTerrainShape(info.coord, heightmap);
+            trimmed = correctTerrainShape(info.coord, heightmap);
 //            flattenChunkToCityBorder(chunkX, chunkZ);
         }
 
@@ -554,7 +557,7 @@ public class LostCityTerrainFeature {
 
         ScatteredSettings scatteredSettings = provider.getWorldStyle().getScatteredSettings();
         if (scatteredSettings != null) {
-            if (avoidScattered(info)) {
+            if (avoidScattered(info) && !trimmed) {
                 generateScattered(info, scatteredSettings, heightmap);
             }
         }
@@ -1135,7 +1138,7 @@ public class LostCityTerrainFeature {
      * or up the top layer (6 thick) of the terrain. In a chunk these heights are interpolated
      * (bilinear interpolation).
      */
-    private void correctTerrainShape(ChunkCoord coord, ChunkHeightmap heightmap) {
+    private boolean correctTerrainShape(ChunkCoord coord, ChunkHeightmap heightmap) {
         BuildingInfo info = BuildingInfo.getBuildingInfo(coord, provider);
         BuildingInfo.MinMax mm00 = info.getDesiredMaxHeightL2();
         BuildingInfo.MinMax mm10 = info.getXmax().getDesiredMaxHeightL2();
@@ -1151,6 +1154,7 @@ public class LostCityTerrainFeature {
         float max10 = mm10.max;
         float max01 = mm01.max;
         float max11 = mm11.max;
+        boolean trimmed = false;
         if (max00 < 256 || max10 < 256 || max01 < 256 || max11 < 256 ||
                 min00 < 256 || min10 < 256 || min01 < 256 || min11 < 256) {
             // We need to fit the terrain between the upper and lower mesh here
@@ -1194,11 +1198,13 @@ public class LostCityTerrainFeature {
 
                     if (!moved) {
                         float minheight = minh0 + (minh1 - minh0) * (15.0f - z) / 15.0f;
-                        moveUp(x, z, (int) minheight, info.waterLevel > info.groundLevel);
+                        moved = moveUp(x, z, (int) minheight, info.waterLevel > info.groundLevel);
                     }
+                    trimmed |= moved;
                 }
             }
         }
+        return trimmed;
     }
 
     // Return true if state is air or liquid
@@ -1223,7 +1229,7 @@ public class LostCityTerrainFeature {
         return Tools.hasTag(state.getBlock(), LostTags.FOLIAGE_TAG);
     }
 
-    private void moveUp(int x, int z, int height, boolean dowater) {
+    private boolean moveUp(int x, int z, int height, boolean dowater) {
         // Find the first non-empty block starting at the given height
         driver.current(x, height, z);
         int minHeight = provider.getWorld().getMinBuildHeight();
@@ -1233,7 +1239,7 @@ public class LostCityTerrainFeature {
         }
 
         if (driver.getY() >= height) {
-            return; // Nothing to do
+            return false; // Nothing to do
         }
 
         int idx = driver.getY();    // Points to non-empty block below the empty block
@@ -1247,6 +1253,7 @@ public class LostCityTerrainFeature {
             driver.decY();
             idx--;
         }
+        return true;
     }
 
     private final BlockState[] buffer = new BlockState[6];

--- a/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
+++ b/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
@@ -2434,7 +2434,6 @@ public class LostCityTerrainFeature {
                             } else if (getStatesNeedingPoiUpdate().contains(b)) {
                                 // If this block has POI data we need to delay setting it
                                 GlobalTodo.getData(provider.getWorld().getLevel()).addPoi(driver.getCurrentCopy(), b);
-                                b = air;
                             } else if (getStatesNeedingLightingUpdate().contains(b)) {
                                 updateNeeded(info, driver.getCurrentCopy());
                             } else if (getStatesNeedingTodo().contains(b)) {


### PR DESCRIPTION
Fixed the scattered building can generate on air when there's a terrain correction in the current chunk.
