### PR TITLE
Fix chest not rendering when it randomly has no loot

### DIFF
--- a/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
+++ b/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
@@ -2810,7 +2810,7 @@ public class LostCityTerrainFeature {
         BlockEntity tileentity = world.getBlockEntity(pos);
         if (random.nextFloat() < diminfo.getProfile().CHEST_WITHOUT_LOOT_CHANCE) {
             if (tileentity instanceof RandomizableContainerBlockEntity) {
-                tileentity.makeDirty();
+                tileentity.setChanged();
             }
             return;
         }

--- a/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
+++ b/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
@@ -2807,10 +2807,13 @@ public class LostCityTerrainFeature {
     }
 
     public static void createLoot(BuildingInfo info, RandomSource random, LevelAccessor world, BlockPos pos, BuildingInfo.ConditionTodo todo, IDimensionInfo diminfo) {
+        BlockEntity tileentity = world.getBlockEntity(pos);
         if (random.nextFloat() < diminfo.getProfile().CHEST_WITHOUT_LOOT_CHANCE) {
+            if (tileentity instanceof RandomizableContainerBlockEntity) {
+                tileentity.makeDirty()
+            }
             return;
         }
-        BlockEntity tileentity = world.getBlockEntity(pos);
         if (tileentity instanceof RandomizableContainerBlockEntity) {
             if (todo != null) {
                 String lootTable = todo.getCondition();

--- a/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
+++ b/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
@@ -2810,7 +2810,7 @@ public class LostCityTerrainFeature {
         BlockEntity tileentity = world.getBlockEntity(pos);
         if (random.nextFloat() < diminfo.getProfile().CHEST_WITHOUT_LOOT_CHANCE) {
             if (tileentity instanceof RandomizableContainerBlockEntity) {
-                tileentity.makeDirty()
+                tileentity.makeDirty();
             }
             return;
         }


### PR DESCRIPTION
I think this should fix chest rendering when it spawns without a loot table. (Untested, did this through github website ui directly havent actually cloned the repo locally yet or anything.) But its pretty straight forward I think.