### PR TITLE
Fix build errors for 1.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,14 +13,14 @@ buildscript {
     }
 }
 
-plugins { id "com.modrinth.minotaur" version "2.+" }
+plugins { id "com.modrinth.minotaur" version "2.8.7" }
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.parchmentmc.librarian.forgegradle'
 apply plugin: 'eclipse'
 apply plugin: 'com.matthewprenger.cursegradle'
 apply plugin: 'maven-publish'
-if (project.file('../gradletools.gradle').exists()) {
-    apply from: '../gradletools.gradle'
+if (project.file('./gradletools.gradle').exists()) {
+    apply from: './gradletools.gradle'
 } else {
     apply from: 'https://raw.githubusercontent.com/McJtyMods/MultiWorkspace/1.18_tech/gradletools.gradle'
 }

--- a/gradletools.gradle
+++ b/gradletools.gradle
@@ -1,0 +1,242 @@
+project.ext.set("minecraft_version", '1.18.2')
+project.ext.set("forge_version", '40.2.2')
+project.ext.set("jei_version", '1.18.2:9.7.0.196')
+project.ext.set("patchouli_version", '1.18.2-71.1')
+project.ext.set("top_version", '1.18-5.1.0-8')
+project.ext.set("mcjtylib_version", '1.18-6.0.20.27')
+project.ext.set("rftoolsbase_version", '1.18-3.0.11-9')
+project.ext.set("curios_version", '1.18.2-5.0.7.1')
+project.ext.set("lostcities_version", '1.18-5.3.14-18')
+project.ext.set("bookshelf_version", '1.18.2:13.0.13')
+project.ext.set("gamestages_version", '1.18.2:8.0.1')
+project.ext.set("sereneseasons_version", '1.18.2-7.0.0.15')
+
+ext.getChangelogText =  {
+    def changelogFile = file('changelog.txt')
+    String str = ''
+    int lineCount = 0
+    boolean done = false
+    changelogFile.eachLine {
+        if (done || it == null) {
+            return
+        }
+        if (it.size() > 1) {
+            def temp = it
+            if (lineCount == 0) {
+                temp = "${modname} ${version}"
+                temp = "<h2>$temp</h2>"
+            } else if (it.startsWith('-')) {
+                temp = "&nbsp;&nbsp;&nbsp;$temp"
+                temp = temp.replaceAll("(\\S+\\/\\S+)#([0-9]+)\\b", "<a href=\"https://github.com/\$1/issues/\$2\">\$0</a>");
+                temp = temp.replaceAll("#([0-9]+)\\b(?!<\\/a>)", "<a href=\"https://github.com/$github_project/issues/\$1\">\$0</a>");
+            } else {
+                temp = "<h4>$temp</h4>"
+            }
+            str += "$temp<br/>"
+            lineCount++
+            return
+        } else {
+            done = true
+        }
+    }
+    return str
+}
+
+ext.mc = {
+    dependencies.minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
+}
+
+ext.jei = {
+    dependencies.compileOnly fg.deobf("mezz.jei:jei-${jei_version}:api")
+    dependencies.runtimeOnly fg.deobf("mezz.jei:jei-${jei_version}")
+}
+
+ext.patchouli = {
+    dependencies.implementation fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}") {
+        transitive = false
+    }
+}
+
+ext.gamestages = {
+    dependencies.compileOnly fg.deobf("net.darkhax.bookshelf:Bookshelf-Forge-${bookshelf_version}")
+    dependencies.compileOnly fg.deobf("net.darkhax.gamestages:GameStages-Forge-${gamestages_version}")
+}
+
+ext.sereneseasons = {
+    dependencies.compileOnly "com.github.glitchfiend:SereneSeasons:${sereneseasons_version}"
+}
+
+ext.top = {
+    if (findProject(':TheOneProbe') != null) {
+        dependencies.implementation project(':TheOneProbe')
+    } else {
+        dependencies.implementation fg.deobf(project.dependencies.create("mcjty.theoneprobe:theoneprobe:${top_version}") {
+            transitive = false
+        })
+    }
+}
+
+ext.mcjtylib = {
+    if (findProject(':McJtyLib') != null) {
+        dependencies.implementation project(':McJtyLib')
+    } else {
+        dependencies.implementation fg.deobf (project.dependencies.create("com.github.mcjty:mcjtylib:${mcjtylib_version}") {
+            transitive = false
+        })
+    }
+}
+
+ext.rftoolsbase = {
+    if (findProject(':RFToolsBase') != null) {
+        dependencies.implementation project(':RFToolsBase')
+    } else {
+        dependencies.implementation fg.deobf (project.dependencies.create("com.github.mcjty:rftoolsbase:${rftoolsbase_version}") {
+            transitive = false
+        })
+    }
+}
+
+ext.curios = {
+    dependencies.runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}")
+    dependencies.compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}:api")
+}
+
+ext.lostcities = {
+    if (findProject(':LostCities') != null) {
+        dependencies.implementation project(':LostCities')
+    } else {
+        dependencies.implementation fg.deobf (project.dependencies.create("com.github.mcjty:lostcities:${lostcities_version}") {
+            transitive = false
+        })
+    }
+}
+
+ext.modrinth = { opt, req, versions ->
+    tasks.modrinth.enabled = project.hasProperty('modrinth_token')
+    modrinth {
+        if (project.hasProperty('modrinth_token')) {
+            token = project.modrinth_token
+        }
+        projectId = project.projectSlug
+        versionType = project.curse_type
+        versionName = "${modname} - ${version}"
+        uploadFile = jar
+        gameVersions = [project.minecraft_version] + versions
+        changelog = System.getenv('CHANGELOG') == null || System.getenv('CHANGELOG').equals('none') ? getChangelogText() : System.getenv('CHANGELOG')
+        dependencies {
+            opt.each { lib ->
+                optional.project lib
+            }
+            req.each { lib ->
+                required.project lib
+            }
+        }
+    }
+}
+
+ext.cfdeps = { optional, required, versions ->
+    tasks.curseforge.enabled = project.hasProperty('curseforge_key')
+    curseforge {
+        if (project.hasProperty('curseforge_key')) {
+            apiKey = project.curseforge_key
+        }
+
+        project {
+            id = project.projectId
+            changelog = System.getenv('CHANGELOG') == null || System.getenv('CHANGELOG').equals('none') ? getChangelogText() : System.getenv('CHANGELOG')
+            changelogType = 'html'
+            releaseType = project.curse_type
+            addGameVersion project.minecraft_version
+            versions.each { v ->
+                addGameVersion v
+            }
+            mainArtifact(jar) {
+                displayName = "${modname} - ${version}"
+            }
+            relations {
+                optional.each { lib ->
+                    optionalLibrary lib
+                }
+                required.each { lib ->
+                    requiredDependency lib
+                }
+            }
+        }
+    }
+}
+
+ext.runs = { name ->
+    minecraft {
+        mappings channel: 'parchment', version: "2022.06.05-1.18.2"
+//        mappings channel: 'official', version: "${minecraft_version}"
+        accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
+
+        runs {
+            client = {
+                property 'mixin.env.remapRefMap', 'true'
+                property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
+                properties 'forge.logging.markers': ''
+                properties 'forge.logging.console.level': 'debug'
+                workingDirectory project.file('run').canonicalPath
+                source sourceSets.main
+            }
+            server = {
+                property 'mixin.env.remapRefMap', 'true'
+                property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
+                properties 'forge.logging.markers': ''
+                properties 'forge.logging.console.level': 'debug'
+                workingDirectory project.file('run').canonicalPath
+                source sourceSets.main
+            }
+            data = {
+                property 'mixin.env.remapRefMap', 'true'
+                property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
+                workingDirectory project.file('run').canonicalPath
+                property 'forge.logging.markers', ''
+                property 'forge.logging.console.level', 'debug'
+                args '--mod', name, '--all', '--output', file('src/generated/resources/'), '--existing', sourceSets.main.resources.srcDirs[0]
+                source sourceSets.main
+            }
+        }
+    }
+}
+
+ext.jars = { name ->
+    jar {
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+        manifest {
+            attributes 'FMLAT': 'accesstransformer.cfg',
+            "Specification-Title": name,
+            "Specification-Vendor": "McJty",
+            "Specification-Version": "1",
+            "Implementation-Title": project.name,
+            "Implementation-Version": "${version}",
+            "Implementation-Vendor" :"McJty",
+            "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
+        }
+    }
+}
+
+ext.publish = {
+    // Example configuration to allow publishing using the maven-publish task
+    // we define a custom artifact that is sourced from the reobfJar output task
+    // and then declare that to be published
+    // Note you'll need to add a repository here
+    def reobfFile = file("$buildDir/reobfJar/output.jar")
+    def reobfArtifact = artifacts.add('default', reobfFile) {
+        type 'jar'
+        builtBy 'reobfJar'
+    }
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                artifact reobfArtifact
+            }
+        }
+        repositories {
+            maven {
+                url "file:///${project.projectDir}/mcmodsrepo"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<ul>
    <li>Change the Minotaur's version to 2.8.7 instead of using dynamic version (2.x).</li>
    <li>Additionally creates the file <b>gradletools.gradle</b> locally because it was receiving <b>429 Too Many Requests</b> every time from Github.</li>
    <li>Update the path to gradletools.gradle on <b>build.gradle.</b>
</ul>