### PR TITLE
7.4.8 - Fixed spawn point doesn't update world spawn itself, only player respawn.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+1.20-7.4.8:
+- TqLxQuanZ fixed spawn point searching function does not set world spawn itself, but only player spawn point.
+
 1.20-7.4.7:
 - New feature to clean up the cache for unloaded chunks every now and then. This prevents memory leaks
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 modname=LostCities
-version=1.20-7.4.7
+version=1.20-7.4.8
 curse_type=release
 projectId=269024
 projectSlug=the-lost-cities

--- a/src/main/java/mcjty/lostcities/setup/ForgeEventHandlers.java
+++ b/src/main/java/mcjty/lostcities/setup/ForgeEventHandlers.java
@@ -240,6 +240,7 @@ public class ForgeEventHandlers {
                 case DEFAULT, SPHERES -> {
                     if (needsCheck) {
                         BlockPos pos = findSafeSpawnPoint(serverLevel, dimensionInfo, isSuitable, event.getSettings());
+                        serverLevel.setDefaultSpawnPos(pos, 0.0f);
                         event.getSettings().setSpawn(pos, 0.0f);
                         spawnPositions.put(serverLevel.dimension(), pos);
                         event.setCanceled(true);
@@ -247,6 +248,7 @@ public class ForgeEventHandlers {
                 }
                 case FLOATING, SPACE, CAVERN, CAVERNSPHERES -> {
                     BlockPos pos = findSafeSpawnPoint(serverLevel, dimensionInfo, isSuitable, event.getSettings());
+                    serverLevel.setDefaultSpawnPos(pos, 0.0f);
                     event.getSettings().setSpawn(pos, 0.0f);
                     spawnPositions.put(serverLevel.dimension(), pos);
                     event.setCanceled(true);


### PR DESCRIPTION
This causes an issue where, if the player dies after they remove a bed with a newer spawn point, meaning they have no respawn point at all, they'll be send to the original world spawn, while it should be the world spawn already set with the safe spawn search itself.