### PR TITLE
Memory optimization for PostTodo

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+1.20-7.4.12:
+- TqLxQuanZ added a memory optimization on crowded city generation from 120MB to 15MB.
+
 1.20-7.4.11:
 - Implement a better caching system which keeps track of how long ago something was last accessed. This should improve performance
 - Extended the world settings with four new options: vinewest, vineeast, vinesouth, and vinenorth. With these you can change the vines that are used for the buildings

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Upcoming:
-- Implement a better caching system which keeps track of how long ago something was last accessed. This should improve performance
-- Extended the world settings with four new options: vinewest, vineeast, vinesouth, and vinenorth. With these you can change the vines that are used for the buildings
+- Implement a better caching system which keeps track of how long ago something was last accessed. This should improve performance.
+- Extended the world settings with four new options: vinewest, vineeast, vinesouth, and vinenorth. With these you can change the vines that are used for the buildings.
+- Fixed an issue where cache cleaning can cause the server to stuck due to bridge generation.
 
 1.20-7.4.10:
 - TqLxQuanZ fixed single player forceSpawnParts having race condition not working properly on setting world spawn during single player.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 modname=LostCities
-version=1.20-7.4.11
+version=1.20-7.4.12
 curse_type=release
 projectId=269024
 projectSlug=the-lost-cities

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 modname=LostCities
-version=1.20-7.4.10
+version=1.20-7.4.11
 curse_type=release
 projectId=269024
 projectSlug=the-lost-cities

--- a/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
+++ b/src/main/java/mcjty/lostcities/worldgen/LostCityTerrainFeature.java
@@ -1849,8 +1849,9 @@ public class LostCityTerrainFeature {
         world.getChunk(pos).setBlockEntityNbt(tag);
         if (b.getBlock() == Blocks.COMMAND_BLOCK) {
             info.addPostTodo(pos, () -> {
-                ((ServerChunkCache)world.getChunkSource()).blockChanged(pos);
-                world.scheduleTick(pos, b.getBlock(), 1);
+                WorldGenLevel inWorld = info.provider.getWorld();
+                ((ServerChunkCache)inWorld.getChunkSource()).blockChanged(pos);
+                inWorld.scheduleTick(pos, b.getBlock(), 1);
             });
         }
         return b;
@@ -1883,9 +1884,10 @@ public class LostCityTerrainFeature {
         if (!info.noLoot) {
             BlockPos pos = driver.getCurrentCopy();
             info.addPostTodo(pos, () -> {
-                if (!world.getBlockState(pos).isAir()) {
-                    world.setBlock(pos, b, Block.UPDATE_CLIENTS);
-                    generateLoot(info, world, pos, new BuildingInfo.ConditionTodo(inf.loot(), part.getName(), info));
+                WorldGenLevel inWorld = info.provider.getWorld();
+                if (!inWorld.getBlockState(pos).isAir()) {
+                    inWorld.setBlock(pos, b, Block.UPDATE_CLIENTS);
+                    generateLoot(info, inWorld, pos, new BuildingInfo.ConditionTodo(inf.loot(), part.getName(), info));
                 }
             });
         }
@@ -1916,8 +1918,9 @@ public class LostCityTerrainFeature {
                         });
                     } else {
                         info.addPostTodo(pos, () -> {
+                            WorldGenLevel inWorld = info.provider.getWorld();
                             BlockState state = finalB.setValue(SaplingBlock.STAGE, 1);
-                            world.setBlock(pos, state, Block.UPDATE_ALL_IMMEDIATE);
+                            inWorld.setBlock(pos, state, Block.UPDATE_ALL_IMMEDIATE);
                         });
                     }
                 }

--- a/src/main/java/mcjty/lostcities/worldgen/lost/BuildingInfo.java
+++ b/src/main/java/mcjty/lostcities/worldgen/lost/BuildingInfo.java
@@ -1348,7 +1348,8 @@ public class BuildingInfo implements ILostChunkInfo {
         xBridgeType = bt;
         // Here we can automatically mark the rest of the bridge as ok. Saves on calculation
         i = i.getXmin();
-        while (i != minimum) {
+        ChunkCoord minCoord = minimum.coord;
+        while (!i.coord.equals(minCoord)) {
             i.xBridgeType = bt;
             i.xBridgeTypeCalculated = true;
             i.zBridgeType = null;
@@ -1416,7 +1417,8 @@ public class BuildingInfo implements ILostChunkInfo {
         zBridgeType = bt;
         // Here we can automatically mark the rest of the bridge as ok. Saves on calculation
         i = i.getZmin();
-        while (i != minimum) {
+        ChunkCoord minCoord = minimum.coord;
+        while (!i.coord.equals(minCoord)) {
             i.zBridgeType = bt;
             i.zBridgeTypeCalculated = true;
             i.xBridgeType = null;

--- a/src/main/java/mcjty/lostcities/worldgen/lost/regassets/BuildingPartRE.java
+++ b/src/main/java/mcjty/lostcities/worldgen/lost/regassets/BuildingPartRE.java
@@ -52,7 +52,7 @@ public class BuildingPartRE implements IAsset<BuildingPartRE> {
         }
         this.xSize = xSize;
         this.zSize = zSize;
-        this.refPaletteName = refpalette.orElse(null);
+        this.refPaletteName = refpalette.map(String::intern).orElse(null);
         this.localPalette = locpalette.orElse(null);
         this.metadata = metadata.orElse(null);
     }

--- a/src/main/java/mcjty/lostcities/worldgen/lost/regassets/BuildingPartRE.java
+++ b/src/main/java/mcjty/lostcities/worldgen/lost/regassets/BuildingPartRE.java
@@ -46,7 +46,7 @@ public class BuildingPartRE implements IAsset<BuildingPartRE> {
         for (List<String> slice : slices) {
             StringBuilder builder = new StringBuilder();
             for (String s : slice) {
-                builder.append(s.intern());
+                builder.append(s);
             }
             this.slices[idx++] = builder.toString();
         }

--- a/src/main/java/mcjty/lostcities/worldgen/lost/regassets/BuildingPartRE.java
+++ b/src/main/java/mcjty/lostcities/worldgen/lost/regassets/BuildingPartRE.java
@@ -46,7 +46,7 @@ public class BuildingPartRE implements IAsset<BuildingPartRE> {
         for (List<String> slice : slices) {
             StringBuilder builder = new StringBuilder();
             for (String s : slice) {
-                builder.append(s);
+                builder.append(s.intern());
             }
             this.slices[idx++] = builder.toString();
         }

--- a/src/main/java/mcjty/lostcities/worldgen/lost/regassets/BuildingRE.java
+++ b/src/main/java/mcjty/lostcities/worldgen/lost/regassets/BuildingRE.java
@@ -53,10 +53,10 @@ public class BuildingRE implements IAsset<BuildingRE> {
                       Optional<Integer> minCellars, Optional<Integer> minFloors, Optional<Integer> maxCellars, Optional<Integer> maxFloors,
                       Optional<Boolean> allowDoors, Optional<Boolean> allowFillers, Optional<Boolean> overrideFloors,
                       Optional<Float> prefersLonely, List<PartRef> partRefs, Optional<List<PartRef>> partRefs2) {
-        this.refPaletteName = refpalette.orElse(null);
+        this.refPaletteName = refpalette.map(String::intern).orElse(null);
         this.localPalette = locpalette.orElse(null);
         this.fillerBlock = filler.charAt(0);
-        this.rubbleBlock = rubble.orElse(null);
+        this.rubbleBlock = rubble.map(String::intern).orElse(null);
         this.minCellars = minCellars.orElse(-1);
         this.maxCellars = maxCellars.orElse(-1);
         this.minFloors = minFloors.orElse(-1);

--- a/src/main/java/mcjty/lostcities/worldgen/lost/regassets/ScatteredRE.java
+++ b/src/main/java/mcjty/lostcities/worldgen/lost/regassets/ScatteredRE.java
@@ -35,7 +35,7 @@ public class ScatteredRE implements IAsset<ScatteredRE> {
                        ScatteredBuilding.TerrainHeight terrainheight, ScatteredBuilding.TerrainFix terrainfix,
                        int heightoffset) {
         this.buildings = buildings.orElse(null);
-        this.multibuilding = multibuilding.orElse(null);
+        this.multibuilding = multibuilding.map(String::intern).orElse(null);
         this.rotatable = rotatable.orElse(false);
         this.terrainheight = terrainheight;
         this.terrainfix = terrainfix;

--- a/src/main/java/mcjty/lostcities/worldgen/lost/regassets/data/ConditionPart.java
+++ b/src/main/java/mcjty/lostcities/worldgen/lost/regassets/data/ConditionPart.java
@@ -58,6 +58,6 @@ public class ConditionPart extends ConditionTest {
         super(top, ground, cellar, isbuilding, issphere, floor, chunkx, chunkz, convertSetOrString(belowpart), convertSetOrString(inpart),
                 convertSetOrString(inbuilding), convertSetOrString(inbiome), range);
         this.factor = factor;
-        this.value = value;
+        this.value = value.intern();
     }
 }

--- a/src/main/java/mcjty/lostcities/worldgen/lost/regassets/data/PaletteEntry.java
+++ b/src/main/java/mcjty/lostcities/worldgen/lost/regassets/data/PaletteEntry.java
@@ -2,6 +2,7 @@ package mcjty.lostcities.worldgen.lost.regassets.data;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.nbt.CompoundTag;
 
 import java.util.HashMap;
@@ -29,7 +30,8 @@ public class PaletteEntry {
             ).apply(instance, PaletteEntry::new));
 
     // Used for reducing the memory usage when stored in the game client, we shouldn't even have duplicate pools as they're very expensive - Quan
-    private static final Map<CompoundTag, CompoundTag> TAG_POOL = new HashMap<>();
+    private static final ObjectOpenHashSet<List<BlockEntry>> LIST_POOL = new ObjectOpenHashSet<>(512);
+    private static final ObjectOpenHashSet<CompoundTag> TAG_POOL = new ObjectOpenHashSet<>(512);
 
     private String chr;
     private String block;
@@ -103,13 +105,31 @@ public class PaletteEntry {
         return tag;
     }
 
-    private static CompoundTag deduplicate(CompoundTag incomingTag) {
-        if (incomingTag == null || incomingTag.isEmpty()) {
+    private static List<BlockEntry> deduplicateList(List<BlockEntry> incoming) {
+        if (incoming == null || incoming.isEmpty()) {
             return null;
         }
-        // If the tag exists in the pool, return the existing one.
-        // If not, put this one in and return it.
-        return TAG_POOL.computeIfAbsent(incomingTag, t -> t);
+        List<BlockEntry> immutable = List.copyOf(incoming);
+        List<BlockEntry> existing = LIST_POOL.get(immutable);
+        if (existing != null) {
+            return existing;
+        }
+
+        LIST_POOL.add(immutable);
+        return immutable;
+    }
+
+    private static CompoundTag deduplicateTag(CompoundTag incoming) {
+        if (incoming == null || incoming.isEmpty()) {
+            return null;
+        }
+
+        CompoundTag existing = TAG_POOL.get(incoming);
+        if (existing != null) {
+            return existing;
+        }
+        TAG_POOL.add(incoming);
+        return incoming;
     }
 
     public PaletteEntry(String chr, Optional<String> block, Optional<String> variant, Optional<String> frompalette,
@@ -120,12 +140,12 @@ public class PaletteEntry {
         this.block = block.map(String::intern).orElse(null);
         this.variant = variant.orElse(null);
         this.frompalette = frompalette.map(String::intern).orElse(null);
-        this.blocks = blocks.orElse(null);
+        this.blocks = deduplicateList(blocks.orElse(null));
         this.damaged = damaged.map(String::intern).orElse(null);
         this.mob = mob.map(String::intern).orElse(null);
         this.loot = loot.map(String::intern).orElse(null);
         this.torch = torch.orElse(null);
-        this.tag = deduplicate(tag.orElse(null));
+        this.tag = deduplicateTag(tag.orElse(null));
     }
 
     @Override

--- a/src/main/java/mcjty/lostcities/worldgen/lost/regassets/data/PaletteEntry.java
+++ b/src/main/java/mcjty/lostcities/worldgen/lost/regassets/data/PaletteEntry.java
@@ -4,7 +4,9 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.nbt.CompoundTag;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -25,6 +27,9 @@ public class PaletteEntry {
                     Codec.BOOL.optionalFieldOf("torch").forGetter(l -> Optional.ofNullable(l.getTorch())),
                     CompoundTag.CODEC.optionalFieldOf("tag").forGetter(l -> Optional.ofNullable(l.getTag()))
             ).apply(instance, PaletteEntry::new));
+
+    // Used for reducing the memory usage when stored in the game client, we shouldn't even have duplicate pools as they're very expensive - Quan
+    private static final Map<CompoundTag, CompoundTag> TAG_POOL = new HashMap<>();
 
     private String chr;
     private String block;
@@ -49,12 +54,6 @@ public class PaletteEntry {
     public static PaletteEntry variant(String variant) {
         PaletteEntry entry = new PaletteEntry();
         entry.variant = variant;
-        return entry;
-    }
-
-    public static PaletteEntry frompalette(String frompalette) {
-        PaletteEntry entry = new PaletteEntry();
-        entry.frompalette = frompalette;
         return entry;
     }
 
@@ -104,20 +103,29 @@ public class PaletteEntry {
         return tag;
     }
 
+    private static CompoundTag deduplicate(CompoundTag incomingTag) {
+        if (incomingTag == null || incomingTag.isEmpty()) {
+            return null;
+        }
+        // If the tag exists in the pool, return the existing one.
+        // If not, put this one in and return it.
+        return TAG_POOL.computeIfAbsent(incomingTag, t -> t);
+    }
+
     public PaletteEntry(String chr, Optional<String> block, Optional<String> variant, Optional<String> frompalette,
                         Optional<List<BlockEntry>> blocks, Optional<String> damaged,
                         Optional<String> mob, Optional<String> loot, Optional<Boolean> torch,
                         Optional<CompoundTag> tag) {
-        this.chr = chr;
-        this.block = block.orElse(null);
+        this.chr = chr.intern();
+        this.block = block.map(String::intern).orElse(null);
         this.variant = variant.orElse(null);
-        this.frompalette = frompalette.orElse(null);
+        this.frompalette = frompalette.map(String::intern).orElse(null);
         this.blocks = blocks.orElse(null);
-        this.damaged = damaged.orElse(null);
-        this.mob = mob.orElse(null);
-        this.loot = loot.orElse(null);
+        this.damaged = damaged.map(String::intern).orElse(null);
+        this.mob = mob.map(String::intern).orElse(null);
+        this.loot = loot.map(String::intern).orElse(null);
         this.torch = torch.orElse(null);
-        this.tag = tag.orElse(null);
+        this.tag = deduplicate(tag.orElse(null));
     }
 
     @Override

--- a/src/main/java/mcjty/lostcities/worldgen/lost/regassets/data/PartRef.java
+++ b/src/main/java/mcjty/lostcities/worldgen/lost/regassets/data/PartRef.java
@@ -53,6 +53,6 @@ public class PartRef extends ConditionTest {
                    Optional<String> range) {
         super(top, ground, cellar, isbuilding, issphere, floor, chunkx, chunkz, convertSetOrString(belowpart), convertSetOrString(inpart),
                 convertSetOrString(inbuilding), convertSetOrString(inbiome), range);
-        this.part = part;
+        this.part = part.intern();
     }
 }


### PR DESCRIPTION
This should makes the generation less overhead due to all the crazy blocks being added to PostTodo list and clogging the memory, based on how many blocks need to update their NBT or blockstates update.