### PR TITLE
feat: add config toggle to enable/disable Lost City dimension

### DIFF
--- a/src/main/java/mcjty/lostcities/setup/Config.java
+++ b/src/main/java/mcjty/lostcities/setup/Config.java
@@ -22,6 +22,7 @@ public class Config {
     public static final boolean DEBUG = false;
 
     public static ModConfigSpec.ConfigValue<String> SPECIAL_BED_BLOCK;// = "minecraft:diamond_block";
+    public static ModConfigSpec.BooleanValue DIMENSION_ENABLED;
 
     private static final String[] DEFAULT_DIMENSION_PROFILES = new String[] {
             "lostcities:lostcity=biosphere",
@@ -181,6 +182,10 @@ public class Config {
         SPECIAL_BED_BLOCK = SERVER_BUILDER
                 .comment("Block to put underneath a bed so that it qualifies as a teleporter bed")
                 .define("specialBedBlock", "minecraft:diamond_block");
+
+        DIMENSION_ENABLED = SERVER_BUILDER
+                .comment("If true, the Lost City dimension (ID 111) is enabled. Players can teleport by sleeping in a bed placed on two diamond blocks surrounded by six skulls. If false, the dimension is disabled and teleportation is blocked")
+                .define("dimensionEnabled", true);
 
         SELECTED_PROFILE = SERVER_BUILDER.define("selectedProfile", "");
         SELECTED_CUSTOM_JSON = SERVER_BUILDER.define("selectedCustomJson", "");

--- a/src/main/java/mcjty/lostcities/setup/ForgeEventHandlers.java
+++ b/src/main/java/mcjty/lostcities/setup/ForgeEventHandlers.java
@@ -412,6 +412,13 @@ public class ForgeEventHandlers {
             return;
         }
 
+        // Check if the dimension is enabled in config
+        if (!Config.DIMENSION_ENABLED.get()) {
+            event.getEntity().sendSystemMessage(ComponentFactory.literal("The Lost City dimension is currently disabled!").withStyle(ChatFormatting.RED));
+            event.setProblem(Player.BedSleepingProblem.OTHER_PROBLEM);
+            return;
+        }
+
         if (world.dimension() == Registration.DIMENSION) {
             event.setProblem(Player.BedSleepingProblem.OTHER_PROBLEM);
             ServerLevel destWorld = WorldTools.getOverworld(world);


### PR DESCRIPTION
- Added DIMENSION_ENABLED config option (default: true) in server.toml
- When disabled, players receive a red message and teleportation is blocked
- The bed-on-diamond-blocks-with-skulls mechanic already exists and works with this toggle