### PR TITLE
fix: prevent NPE in ChunkDriver when BlockState is null (Tectonic + Terralith compatibility)

### DIFF
--- a/src/main/java/mcjty/lostcities/worldgen/ChunkDriver.java
+++ b/src/main/java/mcjty/lostcities/worldgen/ChunkDriver.java
@@ -240,6 +240,8 @@ public class ChunkDriver {
     }
 
     private BlockState correct(BlockState state) {
+        // FIX #1: null guard - evita NPE cuando palette.get() devuelve null (setBlock ya ignora null)
+        if (state == null) return null;
         int cx = current.getX();
         int cy = current.getY();
         int cz = current.getZ();

--- a/src/main/java/mcjty/lostcities/worldgen/gen/Stuff.java
+++ b/src/main/java/mcjty/lostcities/worldgen/gen/Stuff.java
@@ -68,6 +68,8 @@ public class Stuff {
                 maxheight = info.getCityGroundLevel() + info.getNumFloors() * LostCityTerrainFeature.FLOORHEIGHT + 10; // 10 margine above highest floor
             }
         }
+        // FIX #3: evita ArrayIndexOutOfBounds en SectionCache cuando el terreno se extiende hasta el limite (p.ej. Tectonic Y=320)
+        maxheight = Math.min(maxheight, level.getMaxBuildHeight() - 1);
         int mincount = settings.getMincount();
         int maxcount = settings.getMaxcount();
         RandomSource rand = feature.rand;
@@ -90,10 +92,13 @@ public class Stuff {
                             }
                         }
                         if (ok) {
-                            driver.current(x, y, z);
                             for (int k = 0; k < blocks.length(); k++) {
                                 BlockState block = palette.get(blocks.charAt(k));
-                                driver.add(block);
+                                // FIX #2: salta bloques null pero fija la Y explicitamente para no descuadrar la columna
+                                if (block != null) {
+                                    driver.current(x, y + k, z);
+                                    driver.add(block);
+                                }
                             }
                             break;
                         }


### PR DESCRIPTION
## Problem

When using LostCities together with **Tectonic** and **Terralith** on Forge 1.20.1, 
every city chunk fails to generate with the following error:

java.lang.NullPointerException: Cannot invoke "BlockState.m_60734_()" because "state" is null

at mcjty.lostcities.worldgen.ChunkDriver.correct(ChunkDriver.java:253)

at mcjty.lostcities.worldgen.ChunkDriver.add(ChunkDriver.java:289)

at mcjty.lostcities.worldgen.gen.Stuff.actuallyGenerateStuff(Stuff.java:96)

This error appears on **every single city chunk** (IsCity: true), leaving them 
incomplete or empty. The game does not crash, but city generation is effectively broken.

Related issues: #658, #754
Related upstream issue: https://github.com/Apollounknowndev/tectonic/issues/175

## Root Cause Analysis

Tectonic aggressively modifies vertical terrain scale (`vertical_scale: 1.125`, 
`max_y: 320`), which desynchronizes LostCities' internal height model from the 
actual terrain surface. This causes the air-gate check in `Stuff.actuallyGenerateStuff()` 
to pass on nearly every city chunk, reaching `driver.add(palette.get(char))`.

`CompiledPalette.get(char)` legitimately returns `null` when a character is not 
registered in the palette — a rare latent path that Tectonic's height distortion 
turns into the common case. `ChunkDriver.correct()` then dereferences this null 
state with no guard, causing the NPE.

The null is safe to skip: `setBlock()` already ignores null (line 64), and 
`correct()` itself already returns null for `StructureVoidBlock` (line 265). 
The fix closes the only unguarded entry point.

## Fixes Applied

### FIX #1 — `ChunkDriver.correct()` (essential)
Added null guard at the entry point of `correct()`. This is the single point 
through which both `add()` and `block()` pass, so one guard fixes both call sites.
Returning null is safe and consistent with the existing StructureVoidBlock behavior.

```java
private BlockState correct(BlockState state) {
    // FIX #1: null guard - prevents NPE when palette.get() returns null
    if (state == null) return null;
    ...
}
```

### FIX #2 — `Stuff.actuallyGenerateStuff()` (defense in depth)
Skip null BlockStates in the column placement loop and fix Y position explicitly 
per iteration to avoid misaligning the column when a block is skipped.

```java
for (int k = 0; k < blocks.length(); k++) {
    BlockState block = palette.get(blocks.charAt(k));
    if (block != null) {
        driver.current(x, y + k, z);
        driver.add(block);
    }
}
```

### FIX #3 — `Stuff.actuallyGenerateStuff()` (AIOOBE prevention)
Clamp `maxheight` to `level.getMaxBuildHeight() - 1` to prevent a secondary 
`ArrayIndexOutOfBoundsException` in `SectionCache` when terrain generators like 
Tectonic extend the world to Y=320.

```java
maxheight = Math.min(maxheight, level.getMaxBuildHeight() - 1);
```

## Testing

Tested on a fresh world with the exact combination that triggered the bug:

| Component | Version |
|-----------|---------|
| Minecraft | 1.20.1 |
| Forge | 47.4.10 |
| LostCities | 1.20-7.4.13 (this fix) |
| Tectonic | 3.0.17 (Forge) |
| Terralith | 2.5.4 |
| Profile | standard_everywhere |

**Before fix:** dozens of `Error generating chunk` per session, all city chunks 
incomplete.

**After fix:** zero LostCities errors in the log. City chunks generate correctly.

## Notes

- These fixes do not alter behavior for worlds without Tectonic/Terralith.
- FIX #1 alone is sufficient to eliminate the reported NPE. FIX #2 and #3 
  are hardening improvements.
- The underlying height desynchronization between LostCities and Tectonic 
  remains (cosmetic: cities may not perfectly align with Tectonic's extreme 
  terrain), but the crash and empty chunks are resolved.