### PR TITLE
Fix thread-safety crashes in city generation under parallel worldgen

### DIFF
--- a/src/main/java/mcjty/lostcities/worldgen/ChunkDriver.java
+++ b/src/main/java/mcjty/lostcities/worldgen/ChunkDriver.java
@@ -68,7 +68,21 @@ public class ChunkDriver {
 
     // This version of getBlock() is less optimal but it will work for different chunks
     private BlockState getBlockSafe(BlockPos p) {
-        return isThisChunk(p) ? getBlock(p) : region.getBlockState(p);
+        if (isThisChunk(p)) {
+            return getBlock(p);
+        }
+        // During parallel world generation a neighbouring chunk may not be part of (or ready in)
+        // the current WorldGenRegion. Reading it would throw "Requested chunk unavailable during
+        // world generation" and kill chunk generation. Treat unavailable neighbours as air:
+        // only cosmetic connection states (fences, walls, stairs) depend on these reads
+        if (!region.hasChunk(p.getX() >> 4, p.getZ() >> 4)) {
+            return Blocks.AIR.defaultBlockState();
+        }
+        try {
+            return region.getBlockState(p);
+        } catch (RuntimeException e) {
+            return Blocks.AIR.defaultBlockState();
+        }
     }
 
     private BlockState getBlock(BlockPos p) {
@@ -174,7 +188,17 @@ public class ChunkDriver {
             return adjacent;
         }
         if (newAdjacent != adjacent) {
-            ChunkAccess chunk = region.getChunk(pos);
+            // The adjacent position may be outside the available region during parallel world
+            // generation. In that case just skip the (cosmetic) update
+            if (!region.hasChunk(pos.getX() >> 4, pos.getZ() >> 4)) {
+                return adjacent;
+            }
+            ChunkAccess chunk;
+            try {
+                chunk = region.getChunk(pos);
+            } catch (RuntimeException e) {
+                return adjacent;
+            }
             if (chunk == thisChunk) {
                 setBlock(pos, newAdjacent);
             } else if (chunk.getPersistedStatus().isOrAfter(ChunkStatus.FULL)) {

--- a/src/main/java/mcjty/lostcities/worldgen/LostCityFeature.java
+++ b/src/main/java/mcjty/lostcities/worldgen/LostCityFeature.java
@@ -57,14 +57,22 @@ public class LostCityFeature extends Feature<NoneFeatureConfiguration> {
 
                 int chunkX = center.x;
                 int chunkZ = center.z;
-                diminfo.setWorld(level);
-                try {
-                    diminfo.getFeature().generate(region, region.getChunk(chunkX, chunkZ));
-                } catch (Exception e) {
-                    LostCities.getLogger().error("Error generating chunk {},{}: {}", chunkX, chunkZ, e.getMessage(), e);
-                    e.printStackTrace();
-                    ErrorLogger.logChunkInfo(chunkX, chunkZ, diminfo);
-                    ErrorLogger.report("There was an error generating a chunk. See log for details!");
+                // The terrain feature (and its ChunkDriver) is shared per dimension while the
+                // feature step can run concurrently for different chunks. Serialize the world
+                // swap + generation on the shared feature instance so one thread can never tear
+                // down the driver or swap the region out from under another.
+                // LostCitySphereFeature locks the same monitor
+                LostCityTerrainFeature feature = diminfo.getFeature();
+                synchronized (feature) {
+                    diminfo.setWorld(level);
+                    try {
+                        feature.generate(region, region.getChunk(chunkX, chunkZ));
+                    } catch (Exception e) {
+                        LostCities.getLogger().error("Error generating chunk {},{}: {}", chunkX, chunkZ, e.getMessage(), e);
+                        e.printStackTrace();
+                        ErrorLogger.logChunkInfo(chunkX, chunkZ, diminfo);
+                        ErrorLogger.report("There was an error generating a chunk. See log for details!");
+                    }
                 }
                 return true;
             }

--- a/src/main/java/mcjty/lostcities/worldgen/LostCitySphereFeature.java
+++ b/src/main/java/mcjty/lostcities/worldgen/LostCitySphereFeature.java
@@ -33,8 +33,13 @@ public class LostCitySphereFeature extends Feature<NoneFeatureConfiguration> {
 
                 int chunkX = center.x;
                 int chunkZ = center.z;
-                diminfo.setWorld(level);
-                Spheres.generateSpheres(diminfo.getFeature(), region, region.getChunk(chunkX, chunkZ));
+                // See LostCityFeature.place: the terrain feature and its ChunkDriver are shared
+                // per dimension. Serialize on the same monitor to avoid concurrent driver teardown
+                LostCityTerrainFeature feature = diminfo.getFeature();
+                synchronized (feature) {
+                    diminfo.setWorld(level);
+                    Spheres.generateSpheres(feature, region, region.getChunk(chunkX, chunkZ));
+                }
                 return true;
             }
         }


### PR DESCRIPTION
### Problem

Each dimension caches a single `LostCityTerrainFeature`, which owns a single shared `ChunkDriver`, and `IDimensionInfo.setWorld()` swaps the shared region reference right before every generation. The feature step of chunk generation can run concurrently for different chunks on worker threads, so there is a race: one thread's driver teardown (the `setPrimer(oldRegion, oldChunk)` restore at the end of `generate()`) or region swap can land in the middle of another thread's generation.

Crashes we captured during world creation ("Preparing spawn area"):

- `java.lang.NullPointerException: Cannot invoke "ChunkAccess.getPos()" because "this.primer" is null` at `ChunkDriver.current` (via `Spheres.fillSphere` ← `LostCitySphereFeature.place`)
- `NullPointerException: "this.region" is null` at `ChunkDriver.getBlock`
- `IllegalStateException: Requested chunk unavailable during world generation` at `WorldGenRegion.getChunk` via `getBlockSafe` → `updateAdjacent` → `correct` → `block`
- generation running against another thread's `WorldGenRegion` (visible as reads/writes 3–8 chunks outside the current region)

This reproduces near-instantly with parallel-worldgen mods (C2ME on the Fabric side is how we hit it), but the race itself exists under vanilla parallel chunk generation too.

### Fix

- `LostCityFeature.place` and `LostCitySphereFeature.place` now synchronize the `setWorld` + generate sequence on the shared per-dimension terrain feature instance (both features use the same monitor). Only Lost Cities' own generation is serialized per dimension; the rest of worldgen stays parallel.
- `ChunkDriver.getBlockSafe`/`updateAdjacent` treat neighbouring chunks that aren't available in the current `WorldGenRegion` as air / skip the update instead of throwing — these reads only drive cosmetic connection states (fences, walls, stairs), so a neighbour read can never kill chunk generation anymore.

### Verification

- `./gradlew compileJava` passes on this branch (1.21.11_neo).
- The identical fix, ported to a Fabric/26.2 build of this codebase, was smoke-tested with dedicated-server world creation on fresh worlds using both the `default` and `biosphere` profiles: no exceptions, cities and sphere shells generate. I have not run the NeoForge build in-game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
